### PR TITLE
Add multiple text fields per note UI

### DIFF
--- a/UI/note/note.css
+++ b/UI/note/note.css
@@ -260,10 +260,35 @@ ul {
     font-style: 1.6em;
     font-weight: bolder;
     font-size: 12px;
-    font-family: Helvetica, Arial, sans-serif; 
+    font-family: Helvetica, Arial, sans-serif;
     text-decoration: none;
   }
   .button.edit:hover {
+    background-color:gray;
+    text-decoration: none;
+  }
+  .button.add {
+    position: absolute;
+    top: 65px;
+    right: 5px;
+    width: 25px;
+    height: 25px;
+    border-radius: 50%;
+    color: #FFFFFF;
+    padding: 1em 2em;
+    background: linear-gradient(top, rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.3));
+    background-color: black;
+    text-align: center;
+    line-height: 8px;
+    padding: 9px;
+    border-color: gray;
+    font-style: 1.6em;
+    font-weight: bolder;
+    font-size: 12px;
+    font-family: Helvetica, Arial, sans-serif;
+    text-decoration: none;
+  }
+  .button.add:hover {
     background-color:gray;
     text-decoration: none;
   }

--- a/UI/note/note.js
+++ b/UI/note/note.js
@@ -164,31 +164,32 @@ function deleteNote(){
           },
         });
     }
-    
+
     noteCounter = noteCounter - 1;
-    console.log('note count: ', noteCounter);    
+    console.log('note count: ', noteCounter);
     $(this).parents('.note').remove(); // remove the note on click of corresponding x button
-    
+
     // var index = IDarray.indexOf(deleteID); // get index of deleted note's ID
     // if (index > -1) {
     //     IDarray.splice(index, 1); // remove the deleted note's ID from the ID array
     // }
-    // console.log('Deleted ID: ' + $(this).parents('.note')[0].id); // print out the deleted ID                        
+    // console.log('Deleted ID: ' + $(this).parents('.note')[0].id); // print out the deleted ID
     // console.log('ID array: ' + IDarray); // print out current ID array
 };
 /*----------------------------------Load Note----------------------------------*/
 function loadNote(title, content, ID, Xaxis, Yaxis) {
-    
+
 
     Xaxis = Xaxis-190;
     Yaxis = Yaxis-130;
     var noteTemp =  '<div class="note" id="' + ID + '" style="position: absolute; left:' +Xaxis+ '; top:' +Yaxis+ '">'
                         +'<a href="javascript:;" class="button remove">X</a>'
                         // +'<a href="javascript:;" class="button save">S</a>'
-                        +'<a href="javascript:;" class="button edit">E</a>'                                                
+                        + '<a href="javascript:;" class="button edit">E</a>'
+                        + '<a href="javascript:;" class="button add">+</a>'
                         + 	'<div class="note_cnt">'
                         +		'<textarea class="title" placeholder="Testing title">'+title+'</textarea>'
-                        + 		'<textarea class="cnt" placeholder="Testing description">'+content+'</textarea>' 
+                        + 		'<textarea class="cnt" placeholder="Testing description">'+content+'</textarea>'
                         +	'</div> '
                         +'</div>';
 
@@ -200,15 +201,42 @@ function loadNote(title, content, ID, Xaxis, Yaxis) {
         function(){
             $(this).zIndex(++noteZindex);
         }); // show the loaded note to the UI
-    
+
     noteCounter = noteCounter + 1;
     $('.remove').unbind().click(deleteNote); // onclick of delete button, trigger the deleteNote function
-    // $('.save').click(saveNote);    
-    $('.edit').click(editNote);            
-    $('textarea').autogrow(); // text area grows automatically       
+    // $('.save').click(saveNote);
+    $('.edit').click(editNote);
+    $('.add').click(addExtraNoteField);
+    $('textarea').autogrow(); // text area grows automatically
     $('.note')
-    return false; 
+    return false;
 };
+
+function addExtraNoteField() {
+  //Create the extra note field and append it to the note the user is interacting with
+  var extranote = document.createElement('textarea');
+  extranote.classList.add('cnt');
+  extranote.placeholder = "Enter note description";
+  $(this).parents('.note').children('.note_cnt')[0].appendChild(extranote);
+  //Grab all note description fields
+  var texts = $(this).parents('.note').children('.note_cnt').children('.cnt');
+  var initial_height = parseInt($(texts[0]).css("height"));
+  //Rather than hardcode the class height of 90px, this is completely agnostic to changes in textarea CSS changes
+  var computed_height = (initial_height * (texts.length - 1)) / texts.length;
+  for (var i = 0; i < texts.length; i++) {
+    //Iterate over all current descriptions and set their height
+    $(texts[i]).css("height", computed_height);
+  }
+  if(texts.length == 4) {
+    $(this).parents('.note').children(".add").remove();
+  }
+}
+
+
+
+
+
+
 /*----------------------------------New Note----------------------------------*/
 function newNote() {
         // var arrayLength = IDarray.length;
@@ -232,7 +260,8 @@ function newNote() {
         var noteTemp =  '<div class="note" id="' + ID.toString() + '" style="position: absolute; left:' + Xaxis + '; top:' + Yaxis + '">'
                         +'<a href="javascript:;" class="button remove">X</a>'
                         +'<a href="javascript:;" class="button save">S</a>'
-                        // +'<a href="javascript:;" class="button edit">E</a>'                                                
+                        +'<a href="javascript:;" class="button add">+</a>'
+                        // +'<a href="javascript:;" class="button edit">E</a>'
                         + 	'<div class="note_cnt">'
                         +		'<textarea class="title" placeholder="Enter note title"></textarea>'
                         + 		'<textarea class="cnt" placeholder="Enter note description"></textarea>'
@@ -249,18 +278,19 @@ function newNote() {
 
         console.log($(noteTemp)[0]);
         //position the note according to the array
-       
+
         // $(noteTemp).style.position = "absolute";
         // $(noteTemp).style.left =  +'px';
         // $(noteTemp).style.top =  +'px';
 
-        noteCounter = noteCounter + 1;            
+        noteCounter = noteCounter + 1;
         $('.remove').unbind().click(deleteNote); // onclick of delete button, trigger the deleteNote function
         $('.save').unbind().click(saveNote);
-        // $('.edit').click(editNote); 
-        $('textarea').autogrow(); // text area grows automatically              
+        $('.add').click(addExtraNoteField);
+        // $('.edit').click(editNote);
+        $('textarea').autogrow(); // text area grows automatically
         $('.note')
-        return false; 
+        return false;
     // }
 };
 /*----------------------------------Get Position----------------------------------*/


### PR DESCRIPTION
This PR is in reference to #56.

![Concept](https://media.giphy.com/media/xUOxfniAR6ZHt3vaRG/giphy.gif)

Adds the ability for the user to add multiple text fields per note. This is only the UI and does not alter the note-saving functions which will still only save the first field. Most of the work is done via `addExtraNoteField()`, a new function which does the following:

1. Create a new text field and add it to the `note_cnt` div.
2. Grab the height of the first text field and compute the maximum height for each text field.*
3. Set all the `cnt` textareas to the computed height
4. If there's 4 note fields in total, remove the add note button (thus solving the maximum note capacity)

*This code is necessary to remain agnostic to any changes in the note CSS. It assumes the first note field is the maximum height for the div and then calculates based off that. It works very well so long that the assumption holds.

There was a lot of trailing whitespace and differing line endings in the code base which sent my text editor into a mass editing frenzy. I tried to contain it to the best I could to relevant code parts, but it still was pervasive. You can setup a `.gitattributes` file to auto-enforce certain line endings and whitespace rules for future commits.

